### PR TITLE
Removal of unnecessary export for jcd shell function

### DIFF
--- a/src/jcd_function.sh
+++ b/src/jcd_function.sh
@@ -980,9 +980,6 @@ if [[ -n "${BASH_VERSION:-}" ]]; then
     # Hook to clear state when command is executed (but not during completion)
     trap '_jcd_clear_on_execute' DEBUG
 
-    # Export the function
-    export -f jcd
-
     # Clear any existing state when script is loaded to ensure clean start
     _jcd_reset_state
 


### PR DESCRIPTION
## Summary

Removes the unnecessary `export -f jcd` statement from the shell function script.

## Changes

- Removed `export -f jcd` from the bash setup block in [src/jcd_function.sh](src/jcd_function.sh)

## Rationale

The `jcd` function is an interactive `cd` wrapper meant to be used at the current shell prompt. Exporting it to child processes via `export -f` is unnecessary because:

1. **No practical use case**: Any `cd` executed in a child process would only affect that child, not the parent terminal session
2. **Environment pollution**: The entire function body (~1000 lines) gets serialized into the environment variable `BASH_FUNC_jcd%%`, bloating the environment for every child process
3. **Security consideration**: Exported shell functions expand the attack surface (historically exploited in Shellshock CVE-2014-6271)
4. **Bash-specific**: `export -f` only works in bash; the script already handles zsh separately

The function remains fully functional in the interactive shell where it is sourced.